### PR TITLE
Light source now shines equally on all objects

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1362,13 +1362,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &749190316
 GameObject:
   m_ObjectHideFlags: 0
@@ -2119,7 +2119,7 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 3
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -2245,7 +2245,7 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 0
-  serializedVersion: 4
+  serializedVersion: 3
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
Istället för att det är ljusare ju längre ner till höger man är, kommer ljuset nu vara jämnt fördelat på planen.

![dark](https://user-images.githubusercontent.com/38756643/81494346-7b5bdb80-92a8-11ea-946d-0afc7ac123df.png)
_Gamla ljuskällan_


![bright](https://user-images.githubusercontent.com/38756643/81494349-7d259f00-92a8-11ea-8133-5f83033a5dfd.png)
_Nya ljuskällan_

Utöver att plan och landningsbanor ser likadana ut överallt verkar även bakgrunden synas ännu mer :)