### PR TITLE
Add gradually increase speed and decrease spawn rate

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3580,8 +3580,10 @@ MonoBehaviour:
   flightHeight: 5
   maxSpawnTime: 30
   minSpawnTime: 20
+  spawnDecrease: 0
   spawnOffset: 60
   speed: 15
+  speedIncrease: 0
   prefab: {fileID: 1797549254315602, guid: f389977f3e24d09428c7f898dea233ca, type: 3}
   plane: {fileID: 1350809650}
   isActive: 1
@@ -4160,8 +4162,10 @@ MonoBehaviour:
   flightHeight: 2
   maxSpawnTime: 6
   minSpawnTime: 4
+  spawnDecrease: 0.02
   spawnOffset: 60
   speed: 10
+  speedIncrease: 0.1
   prefab: {fileID: 6487564158630302054, guid: ac8148bb9b6f22b4ab3884827fbb0cb9, type: 3}
   plane: {fileID: 1350809650}
   isActive: 1

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -13,8 +13,10 @@ public class Spawner : NetworkBehaviour
     [SerializeField] private float flightHeight = 10f;
     [SerializeField] private float maxSpawnTime = 20f;
     [SerializeField] private float minSpawnTime = 5f;
+    [SerializeField] private float spawnDecrease = 0.1f;
     [SerializeField] private float spawnOffset = 20f;
     [SerializeField] private float speed = 5f;
+    [SerializeField] private float speedIncrease = 0.1f;
     [SerializeField] private GameObject prefab;
     [SerializeField] private Transform plane;
     [SerializeField] private bool isActive = false;
@@ -90,6 +92,10 @@ public class Spawner : NetworkBehaviour
         SpawnEntity();
         
         float randomTime = Random.Range(minSpawnTime, maxSpawnTime);
+
+        if (!(minSpawnTime <= 1)) minSpawnTime -= spawnDecrease;
+        if (!(maxSpawnTime <= 1)) maxSpawnTime -= spawnDecrease;
+
         Invoke("RandomSpawn", randomTime);
     }
 
@@ -113,6 +119,9 @@ public class Spawner : NetworkBehaviour
             ShipHandler shipHandler = entity.GetComponent<ShipHandler>();
             shipHandler.CurrentDirection = CalculateStartVelocity(entity);
             shipHandler.Speed = speed;
+
+            if (speed <= 50) speed += speedIncrease;
+            
             ColorCoordinator colorCoordinator = FindObjectOfType<ColorCoordinator>();
             shipHandler.ShipColor = colorCoordinator.GetRandomPadColor();
         }
@@ -156,7 +165,7 @@ public class Spawner : NetworkBehaviour
         CalculateEdges();
 
         // Initial spawn
-        float randomTime = Random.Range(minSpawnTime+2, maxSpawnTime+2);
+        float randomTime = Random.Range(minSpawnTime + 5, maxSpawnTime + 5);
         Invoke("RandomSpawn", randomTime);
     }
 }


### PR DESCRIPTION
Adderat så att skeppens spawnrate ökar genom att min och max spawn time minskar med spawnDecrease för varje skepp som spawnar samt att hastigheten ökar med speedIncrease för varje skepp. Det går även att justera detta för meteorerna men satte dessa värden till 0 där.
Blev att jag tweakade dessa värden lite i SampleScene men det borde inte vara några breaking changes för andra som jobbar där hoppas jag.